### PR TITLE
Update Eclipse (and some runtimes)

### DIFF
--- a/IDEs/Eclipse/install_Eclipse.sh
+++ b/IDEs/Eclipse/install_Eclipse.sh
@@ -3,8 +3,8 @@
 mkdir /tmp/install-eclipse
 cd /tmp/install-eclipse
 
-curl -LOs https://mirror.umd.edu/Eclipse/technology/epp/downloads/release/2021-09/R/eclipse-java-2021-09-R-linux-gtk-x86_64.tar.gz
-echo '1baeed0f32ea23eed2c1166ab6b92b086f181a030c9a4e59bf424515c558bf1c57c5f6ce077c2f94c12644eb8224f6034b5d724d726636454428c12459f2028f  eclipse-java-2021-09-R-linux-gtk-x86_64.tar.gz' \
+curl -LOs https://mirror.umd.edu/eclipse/technology/epp/downloads/release/2021-12/R/eclipse-java-2021-12-R-linux-gtk-x86_64.tar.gz
+echo '6a1ca4ba3607f512efc5530f1651482c66093b42d71efba19c82e27de028e6fe53a7992d195959586e3ad6264711396df19afbea588602a9b5cad41cbb30b240  eclipse-java-2021-12-R-linux-gtk-x86_64.tar.gz' \
     > eclipse-java-2021-09-R-linux-gtk-x86_64.tar.gz.sha512
 sha512sum -c eclipse-java-2021-09-R-linux-gtk-x86_64.tar.gz.sha512
 

--- a/runtimes/NodeJS/install_NodeJS_12_on_Ubuntu_focal.sh
+++ b/runtimes/NodeJS/install_NodeJS_12_on_Ubuntu_focal.sh
@@ -4,4 +4,4 @@
 # and https://github.com/nodesource/distributions#installation-instructions.
 curl -fsSL https://deb.nodesource.com/setup_12.x | sudo -E bash -
 
-sudo apt-get install -y nodejs=12.22.7-deb-1nodesource1
+sudo apt-get install -y nodejs=12.22.8-deb-1nodesource1

--- a/runtimes/OpenJDK/install_OpenJDK_11_on_Ubuntu_focal.sh
+++ b/runtimes/OpenJDK/install_OpenJDK_11_on_Ubuntu_focal.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
+sudo apt update
 sudo apt-get -y install openjdk-11-jdk

--- a/runtimes/OpenJDK/install_OpenJDK_11_on_Ubuntu_focal.sh
+++ b/runtimes/OpenJDK/install_OpenJDK_11_on_Ubuntu_focal.sh
@@ -1,8 +1,3 @@
 #!/bin/bash
 
-# Note: This echo command exists for image update automation.
-#       When a new patch version is released,
-#       update this echo command to invalidate the layer cache.
-echo "Installing OpenJDK 11.0.11+9-Ubuntu-0ubuntu2.20.04"
-
 sudo apt-get -y install openjdk-11-jdk

--- a/runtimes/OpenJDK/install_OpenJDK_8_on_Ubuntu_focal.sh
+++ b/runtimes/OpenJDK/install_OpenJDK_8_on_Ubuntu_focal.sh
@@ -1,8 +1,3 @@
 #!/bin/bash
 
-# Note: This echo command exists for image update automation.
-#       When a new patch version is released,
-#       update this echo command to invalidate the layer cache.
-echo "Installing OpenJDK 1.8.0_292-8u292-b10-0ubuntu1~20.04-b10"
-
 sudo apt-get -y install openjdk-8-jdk

--- a/runtimes/OpenJDK/install_OpenJDK_8_on_Ubuntu_focal.sh
+++ b/runtimes/OpenJDK/install_OpenJDK_8_on_Ubuntu_focal.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
+sudo apt update
 sudo apt-get -y install openjdk-8-jdk

--- a/runtimes/Python/install_Python_2-7_on_Ubuntu_focal.sh
+++ b/runtimes/Python/install_Python_2-7_on_Ubuntu_focal.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-# Note: This echo command exists for image update automation.
-#       If a new patch version is released,
-#       update this echo command to invalidate the layer cache.
-echo 'Installing python2.7.17-2ubuntu4'
-
 # Note: Python 2.7 is in Ubuntu's default APT repositories,
 #       and deadsnakes does not support Python 2.7 for Ubuntu 20.04 (Focal Fossa).
 sudo apt-get install -y python2

--- a/runtimes/Python/install_Python_3-10_on_Ubuntu_focal.sh
+++ b/runtimes/Python/install_Python_3-10_on_Ubuntu_focal.sh
@@ -2,11 +2,6 @@
 
 sudo add-apt-repository -y ppa:deadsnakes/ppa
 
-# Note: This echo command exists for image update automation.
-#       When a new patch version is released,
-#       update this echo command to automatically invalidate the layer cache.
-echo 'Installing python3.10.0-1+focal1'
-
 sudo apt-get install -y python3.10
 
 sudo cp /usr/bin/python3.10 /usr/bin/python3

--- a/runtimes/Python/install_Python_3-9_on_Ubuntu_focal.sh
+++ b/runtimes/Python/install_Python_3-9_on_Ubuntu_focal.sh
@@ -2,11 +2,6 @@
 
 sudo add-apt-repository -y ppa:deadsnakes/ppa
 
-# Note: This echo command exists for image update automation.
-#       When a new patch version is released,
-#       update this echo command to invalidate the layer cache.
-echo 'Installing python3.9.7-1+focal1'
-
 sudo apt-get install -y python3.9
 
 sudo cp /usr/bin/python3.9 /usr/bin/python3


### PR DESCRIPTION
This should fix our Eclipse image problems, due to a dead mirror URL.

Note: We should look into using a download mirror that supports recently-outdated Eclipse versions.