### PR TITLE
Parallelize prod image builds with dev image builds

### DIFF
--- a/.github/workflows/on_automation_change.yaml
+++ b/.github/workflows/on_automation_change.yaml
@@ -19,7 +19,6 @@ jobs:
       environment: "dev"
 
   build_all_prod:
-    needs: build_all_dev
     uses: itopia-inc/spaces-images/.github/workflows/build_and_publish_all_images.yaml@main
     with:
       environment: "prod"

--- a/.github/workflows/on_external_request_to_build_and_publish_all_images.yaml
+++ b/.github/workflows/on_external_request_to_build_and_publish_all_images.yaml
@@ -10,7 +10,6 @@ jobs:
       environment: "dev"
 
   build_all_prod:
-    needs: build_all_dev
     uses: itopia-inc/spaces-images/.github/workflows/build_and_publish_all_images.yaml@main
     with:
       environment: "prod"

--- a/.github/workflows/on_source_change.yaml
+++ b/.github/workflows/on_source_change.yaml
@@ -17,7 +17,6 @@ jobs:
       environment: "dev"
 
   build_changed_prod:
-    needs: build_changed_dev
     uses: itopia-inc/spaces-images/.github/workflows/build_and_publish_changed_images.yaml@main
     with:
       environment: "prod"


### PR DESCRIPTION
We've decided to try building/publishing prod images even if some dev images failed to build/publish.

This replaces #27 