### PR TITLE
Add missing `start_ide_with_repo` script copies

### DIFF
--- a/complete-setups/Go-and-GoLand/Go_1-16_and_GoLand_on_Ubuntu_focal.Dockerfile
+++ b/complete-setups/Go-and-GoLand/Go_1-16_and_GoLand_on_Ubuntu_focal.Dockerfile
@@ -14,5 +14,7 @@ COPY IDEs/GoLand/create_GoLand_desktop_shortcut.sh /usr/share/dev-scripts/
 COPY IDEs/GoLand/GoLand.desktop /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/create_GoLand_desktop_shortcut.sh'
 
+COPY IDEs/GoLand/start_goland_with_repo.sh /usr/share/dev-scripts/
+
 COPY IDEs/GoLand/configure_GoLand_to_autostart.sh /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/configure_GoLand_to_autostart.sh'

--- a/complete-setups/Go-and-GoLand/Go_1-17_and_GoLand_on_Ubuntu_focal.Dockerfile
+++ b/complete-setups/Go-and-GoLand/Go_1-17_and_GoLand_on_Ubuntu_focal.Dockerfile
@@ -14,5 +14,7 @@ COPY IDEs/GoLand/create_GoLand_desktop_shortcut.sh /usr/share/dev-scripts/
 COPY IDEs/GoLand/GoLand.desktop /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/create_GoLand_desktop_shortcut.sh'
 
+COPY IDEs/GoLand/start_goland_with_repo.sh /usr/share/dev-scripts/
+
 COPY IDEs/GoLand/configure_GoLand_to_autostart.sh /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/configure_GoLand_to_autostart.sh'

--- a/complete-setups/Go-and-VSCode/Go_1-16_and_VSCode_on_Ubuntu_focal.Dockerfile
+++ b/complete-setups/Go-and-VSCode/Go_1-16_and_VSCode_on_Ubuntu_focal.Dockerfile
@@ -7,5 +7,7 @@ LABEL org.opencontainers.image.source="https://github.com/itopia-inc/spaces-imag
 COPY runtimes/Go/install_Go_1-16_on_Linux.sh /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/install_Go_1-16_on_Linux.sh'
 
+COPY IDEs/VSCode/start_vscode_with_repo.sh /usr/share/dev-scripts/
+
 COPY IDEs/VSCode/configure_VSCode_to_autostart.sh /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/configure_VSCode_to_autostart.sh'

--- a/complete-setups/Go-and-VSCode/Go_1-17_and_VSCode_on_Ubuntu_focal.Dockerfile
+++ b/complete-setups/Go-and-VSCode/Go_1-17_and_VSCode_on_Ubuntu_focal.Dockerfile
@@ -7,5 +7,7 @@ LABEL org.opencontainers.image.source="https://github.com/itopia-inc/spaces-imag
 COPY runtimes/Go/install_Go_1-17_on_Linux.sh /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/install_Go_1-17_on_Linux.sh'
 
+COPY IDEs/VSCode/start_vscode_with_repo.sh /usr/share/dev-scripts/
+
 COPY IDEs/VSCode/configure_VSCode_to_autostart.sh /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/configure_VSCode_to_autostart.sh'

--- a/complete-setups/NodeJS-and-VSCode/NodeJS_12_and_VSCode_on_Ubuntu_focal.Dockerfile
+++ b/complete-setups/NodeJS-and-VSCode/NodeJS_12_and_VSCode_on_Ubuntu_focal.Dockerfile
@@ -7,5 +7,7 @@ LABEL org.opencontainers.image.source="https://github.com/itopia-inc/spaces-imag
 COPY runtimes/NodeJS/install_NodeJS_12_on_Ubuntu_focal.sh /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/install_NodeJS_12_on_Ubuntu_focal.sh'
 
+COPY IDEs/VSCode/start_vscode_with_repo.sh /usr/share/dev-scripts/
+
 COPY IDEs/VSCode/configure_VSCode_to_autostart.sh /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/configure_VSCode_to_autostart.sh'

--- a/complete-setups/NodeJS-and-VSCode/NodeJS_14_and_VSCode_on_Ubuntu_focal.Dockerfile
+++ b/complete-setups/NodeJS-and-VSCode/NodeJS_14_and_VSCode_on_Ubuntu_focal.Dockerfile
@@ -7,5 +7,7 @@ LABEL org.opencontainers.image.source="https://github.com/itopia-inc/spaces-imag
 COPY runtimes/NodeJS/install_NodeJS_14_on_Ubuntu_focal.sh /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/install_NodeJS_14_on_Ubuntu_focal.sh'
 
+COPY IDEs/VSCode/start_vscode_with_repo.sh /usr/share/dev-scripts/
+
 COPY IDEs/VSCode/configure_VSCode_to_autostart.sh /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/configure_VSCode_to_autostart.sh'

--- a/complete-setups/NodeJS-and-VSCode/NodeJS_16_and_VSCode_on_Ubuntu_focal.Dockerfile
+++ b/complete-setups/NodeJS-and-VSCode/NodeJS_16_and_VSCode_on_Ubuntu_focal.Dockerfile
@@ -7,5 +7,7 @@ LABEL org.opencontainers.image.source="https://github.com/itopia-inc/spaces-imag
 COPY runtimes/NodeJS/install_NodeJS_16_on_Ubuntu_focal.sh /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/install_NodeJS_16_on_Ubuntu_focal.sh'
 
+COPY IDEs/VSCode/start_vscode_with_repo.sh /usr/share/dev-scripts/
+
 COPY IDEs/VSCode/configure_VSCode_to_autostart.sh /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/configure_VSCode_to_autostart.sh'

--- a/complete-setups/NodeJS-and-WebStorm/NodeJS_12_and_WebStorm_on_Ubuntu_focal.Dockerfile
+++ b/complete-setups/NodeJS-and-WebStorm/NodeJS_12_and_WebStorm_on_Ubuntu_focal.Dockerfile
@@ -14,5 +14,7 @@ COPY IDEs/WebStorm/create_WebStorm_desktop_shortcut.sh /usr/share/dev-scripts/
 COPY IDEs/WebStorm/WebStorm.desktop /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/create_WebStorm_desktop_shortcut.sh'
 
+COPY IDEs/WebStorm/start_webstorm_with_repo.sh /usr/share/dev-scripts/
+
 COPY IDEs/WebStorm/configure_WebStorm_to_autostart.sh /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/configure_WebStorm_to_autostart.sh'

--- a/complete-setups/NodeJS-and-WebStorm/NodeJS_14_and_WebStorm_on_Ubuntu_focal.Dockerfile
+++ b/complete-setups/NodeJS-and-WebStorm/NodeJS_14_and_WebStorm_on_Ubuntu_focal.Dockerfile
@@ -14,5 +14,7 @@ COPY IDEs/WebStorm/create_WebStorm_desktop_shortcut.sh /usr/share/dev-scripts/
 COPY IDEs/WebStorm/WebStorm.desktop /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/create_WebStorm_desktop_shortcut.sh'
 
+COPY IDEs/WebStorm/start_webstorm_with_repo.sh /usr/share/dev-scripts/
+
 COPY IDEs/WebStorm/configure_WebStorm_to_autostart.sh /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/configure_WebStorm_to_autostart.sh'

--- a/complete-setups/NodeJS-and-WebStorm/NodeJS_16_and_WebStorm_on_Ubuntu_focal.Dockerfile
+++ b/complete-setups/NodeJS-and-WebStorm/NodeJS_16_and_WebStorm_on_Ubuntu_focal.Dockerfile
@@ -14,5 +14,7 @@ COPY IDEs/WebStorm/create_WebStorm_desktop_shortcut.sh /usr/share/dev-scripts/
 COPY IDEs/WebStorm/WebStorm.desktop /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/create_WebStorm_desktop_shortcut.sh'
 
+COPY IDEs/WebStorm/start_webstorm_with_repo.sh /usr/share/dev-scripts/
+
 COPY IDEs/WebStorm/configure_WebStorm_to_autostart.sh /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/configure_WebStorm_to_autostart.sh'

--- a/complete-setups/OpenJDK-and-Eclipse/OpenJDK_11_and_Eclipse_on_Ubuntu_focal.Dockerfile
+++ b/complete-setups/OpenJDK-and-Eclipse/OpenJDK_11_and_Eclipse_on_Ubuntu_focal.Dockerfile
@@ -14,5 +14,7 @@ COPY IDEs/Eclipse/create_Eclipse_desktop_shortcut.sh /usr/share/dev-scripts/
 COPY IDEs/Eclipse/Eclipse.desktop /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/create_Eclipse_desktop_shortcut.sh'
 
+COPY IDEs/Eclipse/start_eclipse_with_repo.sh /usr/share/dev-scripts/
+
 COPY IDEs/Eclipse/configure_Eclipse_to_autostart.sh /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/configure_Eclipse_to_autostart.sh'

--- a/complete-setups/OpenJDK-and-Eclipse/OpenJDK_8_and_Eclipse_on_Ubuntu_focal.Dockerfile
+++ b/complete-setups/OpenJDK-and-Eclipse/OpenJDK_8_and_Eclipse_on_Ubuntu_focal.Dockerfile
@@ -14,5 +14,7 @@ COPY IDEs/Eclipse/create_Eclipse_desktop_shortcut.sh /usr/share/dev-scripts/
 COPY IDEs/Eclipse/Eclipse.desktop /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/create_Eclipse_desktop_shortcut.sh'
 
+COPY IDEs/Eclipse/start_eclipse_with_repo.sh /usr/share/dev-scripts/
+
 COPY IDEs/Eclipse/configure_Eclipse_to_autostart.sh /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/configure_Eclipse_to_autostart.sh'

--- a/complete-setups/OpenJDK-and-VSCode/OpenJDK_11_and_VSCode_on_Ubuntu_focal.Dockerfile
+++ b/complete-setups/OpenJDK-and-VSCode/OpenJDK_11_and_VSCode_on_Ubuntu_focal.Dockerfile
@@ -7,5 +7,7 @@ LABEL org.opencontainers.image.source="https://github.com/itopia-inc/spaces-imag
 COPY runtimes/OpenJDK/install_OpenJDK_11_on_Ubuntu_focal.sh /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/install_OpenJDK_11_on_Ubuntu_focal.sh'
 
+COPY IDEs/VSCode/start_vscode_with_repo.sh /usr/share/dev-scripts/
+
 COPY IDEs/VSCode/configure_VSCode_to_autostart.sh /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/configure_VSCode_to_autostart.sh'

--- a/complete-setups/OpenJDK-and-VSCode/OpenJDK_8_and_VSCode_on_Ubuntu_focal.Dockerfile
+++ b/complete-setups/OpenJDK-and-VSCode/OpenJDK_8_and_VSCode_on_Ubuntu_focal.Dockerfile
@@ -7,5 +7,7 @@ LABEL org.opencontainers.image.source="https://github.com/itopia-inc/spaces-imag
 COPY runtimes/OpenJDK/install_OpenJDK_8_on_Ubuntu_focal.sh /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/install_OpenJDK_8_on_Ubuntu_focal.sh'
 
+COPY IDEs/VSCode/start_vscode_with_repo.sh /usr/share/dev-scripts/
+
 COPY IDEs/VSCode/configure_VSCode_to_autostart.sh /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/configure_VSCode_to_autostart.sh'

--- a/complete-setups/Python-and-PyCharm/Python_2-7_and_PyCharm_on_Ubuntu_focal.Dockerfile
+++ b/complete-setups/Python-and-PyCharm/Python_2-7_and_PyCharm_on_Ubuntu_focal.Dockerfile
@@ -14,5 +14,7 @@ COPY IDEs/PyCharm/create_PyCharm_desktop_shortcut.sh /usr/share/dev-scripts/
 COPY IDEs/PyCharm/PyCharm_CE.desktop /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/create_PyCharm_desktop_shortcut.sh'
 
+COPY IDEs/PyCharm/start_pycharm_with_repo.sh /usr/share/dev-scripts/
+
 COPY IDEs/PyCharm/configure_PyCharm_to_autostart.sh /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/configure_PyCharm_to_autostart.sh'

--- a/complete-setups/Python-and-PyCharm/Python_3-10_and_PyCharm_on_Ubuntu_focal.Dockerfile
+++ b/complete-setups/Python-and-PyCharm/Python_3-10_and_PyCharm_on_Ubuntu_focal.Dockerfile
@@ -14,5 +14,7 @@ COPY IDEs/PyCharm/create_PyCharm_desktop_shortcut.sh /usr/share/dev-scripts/
 COPY IDEs/PyCharm/PyCharm_CE.desktop /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/create_PyCharm_desktop_shortcut.sh'
 
+COPY IDEs/PyCharm/start_pycharm_with_repo.sh /usr/share/dev-scripts/
+
 COPY IDEs/PyCharm/configure_PyCharm_to_autostart.sh /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/configure_PyCharm_to_autostart.sh'

--- a/complete-setups/Python-and-PyCharm/Python_3-9_and_PyCharm_on_Ubuntu_focal.Dockerfile
+++ b/complete-setups/Python-and-PyCharm/Python_3-9_and_PyCharm_on_Ubuntu_focal.Dockerfile
@@ -14,5 +14,7 @@ COPY IDEs/PyCharm/create_PyCharm_desktop_shortcut.sh /usr/share/dev-scripts/
 COPY IDEs/PyCharm/PyCharm_CE.desktop /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/create_PyCharm_desktop_shortcut.sh'
 
+COPY IDEs/PyCharm/start_pycharm_with_repo.sh /usr/share/dev-scripts/
+
 COPY IDEs/PyCharm/configure_PyCharm_to_autostart.sh /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/configure_PyCharm_to_autostart.sh'

--- a/complete-setups/Python-and-VSCode/Python_2-7_and_VSCode_on_Ubuntu_focal.Dockerfile
+++ b/complete-setups/Python-and-VSCode/Python_2-7_and_VSCode_on_Ubuntu_focal.Dockerfile
@@ -7,5 +7,7 @@ LABEL org.opencontainers.image.source="https://github.com/itopia-inc/spaces-imag
 COPY runtimes/Python/install_Python_2-7_on_Ubuntu_focal.sh /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/install_Python_2-7_on_Ubuntu_focal.sh'
 
+COPY IDEs/VSCode/start_vscode_with_repo.sh /usr/share/dev-scripts/
+
 COPY IDEs/VSCode/configure_VSCode_to_autostart.sh /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/configure_VSCode_to_autostart.sh'

--- a/complete-setups/Python-and-VSCode/Python_3-10_and_VSCode_on_Ubuntu_focal.Dockerfile
+++ b/complete-setups/Python-and-VSCode/Python_3-10_and_VSCode_on_Ubuntu_focal.Dockerfile
@@ -7,5 +7,7 @@ LABEL org.opencontainers.image.source="https://github.com/itopia-inc/spaces-imag
 COPY runtimes/Python/install_Python_3-10_on_Ubuntu_focal.sh /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/install_Python_3-10_on_Ubuntu_focal.sh'
 
+COPY IDEs/VSCode/start_vscode_with_repo.sh /usr/share/dev-scripts/
+
 COPY IDEs/VSCode/configure_VSCode_to_autostart.sh /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/configure_VSCode_to_autostart.sh'

--- a/complete-setups/Python-and-VSCode/Python_3-9_and_VSCode_on_Ubuntu_focal.Dockerfile
+++ b/complete-setups/Python-and-VSCode/Python_3-9_and_VSCode_on_Ubuntu_focal.Dockerfile
@@ -7,5 +7,7 @@ LABEL org.opencontainers.image.source="https://github.com/itopia-inc/spaces-imag
 COPY runtimes/Python/install_Python_3-9_on_Ubuntu_focal.sh /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/install_Python_3-9_on_Ubuntu_focal.sh'
 
+COPY IDEs/VSCode/start_vscode_with_repo.sh /usr/share/dev-scripts/
+
 COPY IDEs/VSCode/configure_VSCode_to_autostart.sh /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/configure_VSCode_to_autostart.sh'

--- a/complete-setups/all-runtimes-and-VSCode/all_runtimes_and_VSCode_on_Ubuntu_focal.Dockerfile
+++ b/complete-setups/all-runtimes-and-VSCode/all_runtimes_and_VSCode_on_Ubuntu_focal.Dockerfile
@@ -13,5 +13,7 @@ RUN bash -ce '/usr/share/dev-scripts/install_OpenJDK_11_on_Ubuntu_focal.sh'
 COPY runtimes/Python/install_Python_3-10_on_Ubuntu_focal.sh /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/install_Python_3-10_on_Ubuntu_focal.sh'
 
+COPY IDEs/VSCode/start_vscode_with_repo.sh /usr/share/dev-scripts/
+
 COPY IDEs/VSCode/configure_VSCode_to_autostart.sh /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/configure_VSCode_to_autostart.sh'


### PR DESCRIPTION
In most complete setups, IDE desktop shortcuts were failing due to a missing script. This copies the missing scripts into those images.