### PR TITLE
Replace Node.js v12 with v18

### DIFF
--- a/.github/workflows/build_all_images.yaml
+++ b/.github/workflows/build_all_images.yaml
@@ -271,6 +271,7 @@ jobs:
         image_tag_2: ghcr.io/itopia-inc/spaces-images/spaces-ubuntu-goland:focal
         publish: ${{ inputs.publish }}
 
+<<<<<<< HEAD:.github/workflows/build_all_images.yaml
   NodeJS_12:
     runs-on: ubuntu-latest
     steps:
@@ -285,6 +286,8 @@ jobs:
         image_tag_2: ghcr.io/itopia-inc/spaces-images/spaces-ubuntu-nodejs:focal-12
         publish: ${{ inputs.publish }}
 
+=======
+>>>>>>> dcd054e... Replace Node.js v12 with v18:.github/workflows/build_and_publish_all_images.yaml
   NodeJS_14:
     runs-on: ubuntu-latest
     steps:
@@ -313,19 +316,24 @@ jobs:
         image_tag_2: ghcr.io/itopia-inc/spaces-images/spaces-ubuntu-nodejs:focal-16
         publish: ${{ inputs.publish }}
 
-  NodeJS_12_and_VSCode:
+  NodeJS_18:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: ./.github/actions/build-image
       with:
-        dockerfile_path: complete-setups/NodeJS-and-VSCode/NodeJS_12_and_VSCode_on_Ubuntu_focal.Dockerfile
+        dockerfile_path: languages/NodeJS/NodeJS_18_on_Ubuntu_focal.Dockerfile
         environment: ${{ inputs.environment }}
         github_personal_access_token: ${{ secrets.GITHUB_TOKEN }}
         github_username: ${{ github.actor }}
+<<<<<<< HEAD:.github/workflows/build_all_images.yaml
         image_tag_1: ghcr.io/itopia-inc/spaces-images/spaces-ubuntu-nodejs-vscode:20.04-12
         image_tag_2: ghcr.io/itopia-inc/spaces-images/spaces-ubuntu-nodejs-vscode:focal-12
         publish: ${{ inputs.publish }}
+=======
+        image_tag_1: ghcr.io/itopia-inc/spaces-images/spaces-ubuntu-nodejs:20.04-18
+        image_tag_2: ghcr.io/itopia-inc/spaces-images/spaces-ubuntu-nodejs:focal-18
+>>>>>>> dcd054e... Replace Node.js v12 with v18:.github/workflows/build_and_publish_all_images.yaml
 
   NodeJS_14_and_VSCode:
     runs-on: ubuntu-latest
@@ -355,19 +363,24 @@ jobs:
         image_tag_2: ghcr.io/itopia-inc/spaces-images/spaces-ubuntu-nodejs-vscode:focal-16
         publish: ${{ inputs.publish }}
 
-  NodeJS_12_and_WebStorm:
+  NodeJS_18_and_VSCode:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: ./.github/actions/build-image
       with:
-        dockerfile_path: complete-setups/NodeJS-and-WebStorm/NodeJS_12_and_WebStorm_on_Ubuntu_focal.Dockerfile
+        dockerfile_path: complete-setups/NodeJS-and-VSCode/NodeJS_18_and_VSCode_on_Ubuntu_focal.Dockerfile
         environment: ${{ inputs.environment }}
         github_personal_access_token: ${{ secrets.GITHUB_TOKEN }}
         github_username: ${{ github.actor }}
+<<<<<<< HEAD:.github/workflows/build_all_images.yaml
         image_tag_1: ghcr.io/itopia-inc/spaces-images/spaces-ubuntu-nodejs-webstorm:20.04-12
         image_tag_2: ghcr.io/itopia-inc/spaces-images/spaces-ubuntu-nodejs-webstorm:focal-12
         publish: ${{ inputs.publish }}
+=======
+        image_tag_1: ghcr.io/itopia-inc/spaces-images/spaces-ubuntu-nodejs-vscode:20.04-18
+        image_tag_2: ghcr.io/itopia-inc/spaces-images/spaces-ubuntu-nodejs-vscode:focal-18
+>>>>>>> dcd054e... Replace Node.js v12 with v18:.github/workflows/build_and_publish_all_images.yaml
 
   NodeJS_14_and_WebStorm:
     runs-on: ubuntu-latest
@@ -396,6 +409,19 @@ jobs:
         image_tag_1: ghcr.io/itopia-inc/spaces-images/spaces-ubuntu-nodejs-webstorm:20.04-16
         image_tag_2: ghcr.io/itopia-inc/spaces-images/spaces-ubuntu-nodejs-webstorm:focal-16
         publish: ${{ inputs.publish }}
+
+  NodeJS_18_and_WebStorm:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ./.github/actions/build-and-publish-image
+      with:
+        dockerfile_path: complete-setups/NodeJS-and-WebStorm/NodeJS_18_and_WebStorm_on_Ubuntu_focal.Dockerfile
+        environment: ${{ inputs.environment }}
+        github_personal_access_token: ${{ secrets.GITHUB_TOKEN }}
+        github_username: ${{ github.actor }}
+        image_tag_1: ghcr.io/itopia-inc/spaces-images/spaces-ubuntu-nodejs-webstorm:20.04-18
+        image_tag_2: ghcr.io/itopia-inc/spaces-images/spaces-ubuntu-nodejs-webstorm:focal-18
 
   OpenJDK_8:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_changed_images.yaml
+++ b/.github/workflows/build_changed_images.yaml
@@ -46,17 +46,17 @@ jobs:
 
       GoLand_changed: ${{ steps.changes_to_GoLand.outputs.any_changed == 'true' || steps.changes_to_GoLand.outputs.any_deleted == 'true' }}
 
-      NodeJS_12_changed: ${{ steps.changes_to_NodeJS_12.outputs.any_changed == 'true' || steps.changes_to_NodeJS_12.outputs.any_deleted == 'true' }}
       NodeJS_14_changed: ${{ steps.changes_to_NodeJS_14.outputs.any_changed == 'true' || steps.changes_to_NodeJS_14.outputs.any_deleted == 'true' }}
       NodeJS_16_changed: ${{ steps.changes_to_NodeJS_16.outputs.any_changed == 'true' || steps.changes_to_NodeJS_16.outputs.any_deleted == 'true' }}
+      NodeJS_18_changed: ${{ steps.changes_to_NodeJS_18.outputs.any_changed == 'true' || steps.changes_to_NodeJS_18.outputs.any_deleted == 'true' }}
 
-      NodeJS_12_and_VSCode_changed: ${{ steps.changes_to_NodeJS_12_and_VSCode.outputs.any_changed == 'true' || steps.changes_to_NodeJS_12_and_VSCode.outputs.any_deleted == 'true' }}
       NodeJS_14_and_VSCode_changed: ${{ steps.changes_to_NodeJS_14_and_VSCode.outputs.any_changed == 'true' || steps.changes_to_NodeJS_14_and_VSCode.outputs.any_deleted == 'true' }}
       NodeJS_16_and_VSCode_changed: ${{ steps.changes_to_NodeJS_16_and_VSCode.outputs.any_changed == 'true' || steps.changes_to_NodeJS_16_and_VSCode.outputs.any_deleted == 'true' }}
+      NodeJS_18_and_VSCode_changed: ${{ steps.changes_to_NodeJS_18_and_VSCode.outputs.any_changed == 'true' || steps.changes_to_NodeJS_18_and_VSCode.outputs.any_deleted == 'true' }}
 
-      NodeJS_12_and_WebStorm_changed: ${{ steps.changes_to_NodeJS_12_and_WebStorm.outputs.any_changed == 'true' || steps.changes_to_NodeJS_12_and_WebStorm.outputs.any_deleted == 'true' }}
       NodeJS_14_and_WebStorm_changed: ${{ steps.changes_to_NodeJS_14_and_WebStorm.outputs.any_changed == 'true' || steps.changes_to_NodeJS_14_and_WebStorm.outputs.any_deleted == 'true' }}
       NodeJS_16_and_WebStorm_changed: ${{ steps.changes_to_NodeJS_16_and_WebStorm.outputs.any_changed == 'true' || steps.changes_to_NodeJS_16_and_WebStorm.outputs.any_deleted == 'true' }}
+      NodeJS_18_and_WebStorm_changed: ${{ steps.changes_to_NodeJS_18_and_WebStorm.outputs.any_changed == 'true' || steps.changes_to_NodeJS_18_and_WebStorm.outputs.any_deleted == 'true' }}
 
       OpenJDK_8_changed: ${{ steps.changes_to_OpenJDK_8.outputs.any_changed == 'true' || steps.changes_to_OpenJDK_8.outputs.any_deleted == 'true' }}
       OpenJDK_11_changed: ${{ steps.changes_to_OpenJDK_11.outputs.any_changed == 'true' || steps.changes_to_OpenJDK_11.outputs.any_deleted == 'true' }}
@@ -239,13 +239,6 @@ jobs:
         files: |
           IDEs/GoLand/*
 
-    - id: changes_to_NodeJS_12
-      uses: tj-actions/changed-files@v1.1.2
-      with:
-        files: |
-          languages/NodeJS/install_NodeJS_12_on_Ubuntu_focal.sh
-          languages/NodeJS/NodeJS_12_on_Ubuntu_focal.Dockerfile
-
     - id: changes_to_NodeJS_14
       uses: tj-actions/changed-files@v1.1.2
       with:
@@ -260,13 +253,12 @@ jobs:
           languages/NodeJS/install_NodeJS_16_on_Ubuntu_focal.sh
           languages/NodeJS/NodeJS_16_on_Ubuntu_focal.Dockerfile
 
-    - id: changes_to_NodeJS_12_and_VSCode
+    - id: changes_to_NodeJS_18
       uses: tj-actions/changed-files@v1.1.2
       with:
         files: |
-          complete-setups/NodeJS-and-VSCode/NodeJS_12_and_VSCode_on_Ubuntu_focal.Dockerfile
-          IDEs/VSCode/*
-          languages/NodeJS/install_NodeJS_12_on_Ubuntu_focal.sh
+          languages/NodeJS/install_NodeJS_18_on_Ubuntu_focal.sh
+          languages/NodeJS/NodeJS_18_on_Ubuntu_focal.Dockerfile
 
     - id: changes_to_NodeJS_14_and_VSCode
       uses: tj-actions/changed-files@v1.1.2
@@ -284,13 +276,13 @@ jobs:
           IDEs/VSCode/*
           languages/NodeJS/install_NodeJS_16_on_Ubuntu_focal.sh
 
-    - id: changes_to_NodeJS_12_and_WebStorm
+    - id: changes_to_NodeJS_18_and_VSCode
       uses: tj-actions/changed-files@v1.1.2
       with:
         files: |
-          complete-setups/NodeJS-and-WebStorm/NodeJS_12_and_WebStorm_on_Ubuntu_focal.Dockerfile
-          IDEs/WebStorm/*
-          languages/NodeJS/install_NodeJS_12_on_Ubuntu_focal.sh
+          complete-setups/NodeJS-and-VSCode/NodeJS_18_and_VSCode_on_Ubuntu_focal.Dockerfile
+          IDEs/VSCode/*
+          languages/NodeJS/install_NodeJS_18_on_Ubuntu_focal.sh
 
     - id: changes_to_NodeJS_14_and_WebStorm
       uses: tj-actions/changed-files@v1.1.2
@@ -307,6 +299,14 @@ jobs:
           complete-setups/NodeJS-and-WebStorm/NodeJS_16_and_WebStorm_on_Ubuntu_focal.Dockerfile
           IDEs/WebStorm/*
           languages/NodeJS/install_NodeJS_16_on_Ubuntu_focal.sh
+
+    - id: changes_to_NodeJS_18_and_WebStorm
+      uses: tj-actions/changed-files@v1.1.2
+      with:
+        files: |
+          complete-setups/NodeJS-and-WebStorm/NodeJS_18_and_WebStorm_on_Ubuntu_focal.Dockerfile
+          IDEs/WebStorm/*
+          languages/NodeJS/install_NodeJS_18_on_Ubuntu_focal.sh
 
     - id: changes_to_OpenJDK_8
       uses: tj-actions/changed-files@v1.1.2
@@ -623,22 +623,6 @@ jobs:
         image_tag_2: ghcr.io/itopia-inc/spaces-images/spaces-ubuntu-goland:focal
         publish: ${{ inputs.publish }}
 
-  NodeJS_12:
-    needs: detect_image_source_changes
-    if: ${{ needs.detect_image_source_changes.outputs.NodeJS_12_changed == 'true' }}
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: ./.github/actions/build-image
-      with:
-        dockerfile_path: languages/NodeJS/NodeJS_12_on_Ubuntu_focal.Dockerfile
-        environment: ${{ inputs.environment }}
-        github_personal_access_token: ${{ secrets.GITHUB_TOKEN }}
-        github_username: ${{ github.actor }}
-        image_tag_1: ghcr.io/itopia-inc/spaces-images/spaces-ubuntu-nodejs:20.04-12
-        image_tag_2: ghcr.io/itopia-inc/spaces-images/spaces-ubuntu-nodejs:focal-12
-        publish: ${{ inputs.publish }}
-
   NodeJS_14:
     needs: detect_image_source_changes
     if: ${{ needs.detect_image_source_changes.outputs.NodeJS_14_changed == 'true' }}
@@ -671,20 +655,20 @@ jobs:
         image_tag_2: ghcr.io/itopia-inc/spaces-images/spaces-ubuntu-nodejs:focal-16
         publish: ${{ inputs.publish }}
 
-  NodeJS_12_and_VSCode:
+  NodeJS_18:
     needs: detect_image_source_changes
-    if: ${{ needs.detect_image_source_changes.outputs.NodeJS_12_and_VSCode_changed == 'true' }}
+    if: ${{ needs.detect_image_source_changes.outputs.NodeJS_18_changed == 'true' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: ./.github/actions/build-image
       with:
-        dockerfile_path: complete-setups/NodeJS-and-VSCode/NodeJS_12_and_VSCode_on_Ubuntu_focal.Dockerfile
+        dockerfile_path: languages/NodeJS/NodeJS_18_on_Ubuntu_focal.Dockerfile
         environment: ${{ inputs.environment }}
         github_personal_access_token: ${{ secrets.GITHUB_TOKEN }}
         github_username: ${{ github.actor }}
-        image_tag_1: ghcr.io/itopia-inc/spaces-images/spaces-ubuntu-nodejs-vscode:20.04-12
-        image_tag_2: ghcr.io/itopia-inc/spaces-images/spaces-ubuntu-nodejs-vscode:focal-12
+        image_tag_1: ghcr.io/itopia-inc/spaces-images/spaces-ubuntu-nodejs:20.04-18
+        image_tag_2: ghcr.io/itopia-inc/spaces-images/spaces-ubuntu-nodejs:focal-18
         publish: ${{ inputs.publish }}
 
   NodeJS_14_and_VSCode:
@@ -719,20 +703,20 @@ jobs:
         image_tag_2: ghcr.io/itopia-inc/spaces-images/spaces-ubuntu-nodejs-vscode:focal-16
         publish: ${{ inputs.publish }}
 
-  NodeJS_12_and_WebStorm:
+  NodeJS_18_and_VSCode:
     needs: detect_image_source_changes
-    if: ${{ needs.detect_image_source_changes.outputs.NodeJS_12_and_WebStorm_changed == 'true' }}
+    if: ${{ needs.detect_image_source_changes.outputs.NodeJS_18_and_VSCode_changed == 'true' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: ./.github/actions/build-image
       with:
-        dockerfile_path: complete-setups/NodeJS-and-WebStorm/NodeJS_12_and_WebStorm_on_Ubuntu_focal.Dockerfile
+        dockerfile_path: complete-setups/NodeJS-and-VSCode/NodeJS_18_and_VSCode_on_Ubuntu_focal.Dockerfile
         environment: ${{ inputs.environment }}
         github_personal_access_token: ${{ secrets.GITHUB_TOKEN }}
         github_username: ${{ github.actor }}
-        image_tag_1: ghcr.io/itopia-inc/spaces-images/spaces-ubuntu-nodejs-webstorm:20.04-12
-        image_tag_2: ghcr.io/itopia-inc/spaces-images/spaces-ubuntu-nodejs-webstorm:focal-12
+        image_tag_1: ghcr.io/itopia-inc/spaces-images/spaces-ubuntu-nodejs-vscode:20.04-18
+        image_tag_2: ghcr.io/itopia-inc/spaces-images/spaces-ubuntu-nodejs-vscode:focal-18
         publish: ${{ inputs.publish }}
 
   NodeJS_14_and_WebStorm:
@@ -766,6 +750,21 @@ jobs:
         image_tag_1: ghcr.io/itopia-inc/spaces-images/spaces-ubuntu-nodejs-webstorm:20.04-16
         image_tag_2: ghcr.io/itopia-inc/spaces-images/spaces-ubuntu-nodejs-webstorm:focal-16
         publish: ${{ inputs.publish }}
+
+  NodeJS_18_and_WebStorm:
+    needs: detect_image_source_changes
+    if: ${{ needs.detect_image_source_changes.outputs.NodeJS_18_and_WebStorm_changed == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ./.github/actions/build-and-publish-image
+      with:
+        dockerfile_path: complete-setups/NodeJS-and-WebStorm/NodeJS_18_and_WebStorm_on_Ubuntu_focal.Dockerfile
+        github_personal_access_token: ${{ secrets.GITHUB_TOKEN }}
+        github_username: ${{ github.actor }}
+        image_tag_1: ghcr.io/itopia-inc/spaces-images/spaces-ubuntu-nodejs-webstorm:20.04-18
+        image_tag_2: ghcr.io/itopia-inc/spaces-images/spaces-ubuntu-nodejs-webstorm:focal-18
+        environment: ${{ inputs.environment }}
 
   OpenJDK_8:
     needs: detect_image_source_changes

--- a/complete-setups/NodeJS-and-VSCode/NodeJS_18_and_VSCode_on_Ubuntu_focal.Dockerfile
+++ b/complete-setups/NodeJS-and-VSCode/NodeJS_18_and_VSCode_on_Ubuntu_focal.Dockerfile
@@ -4,8 +4,8 @@ FROM ghcr.io/itopia-inc/spaces-base-images/spaces-ubuntu-base:focal
 LABEL org.opencontainers.image.description="itopia Spaces image for Node.js + VS Code on Ubuntu"
 LABEL org.opencontainers.image.source="https://github.com/itopia-inc/spaces-images"
 
-COPY languages/NodeJS/install_NodeJS_12_on_Ubuntu_focal.sh /usr/share/dev-scripts/
-RUN bash -ce '/usr/share/dev-scripts/install_NodeJS_12_on_Ubuntu_focal.sh'
+COPY languages/NodeJS/install_NodeJS_18_on_Ubuntu_focal.sh /usr/share/dev-scripts/
+RUN bash -ce '/usr/share/dev-scripts/install_NodeJS_18_on_Ubuntu_focal.sh'
 
 COPY IDEs/VSCode/start_VSCode_with_repo.sh /usr/share/dev-scripts/
 

--- a/complete-setups/NodeJS-and-WebStorm/NodeJS_18_and_WebStorm_on_Ubuntu_focal.Dockerfile
+++ b/complete-setups/NodeJS-and-WebStorm/NodeJS_18_and_WebStorm_on_Ubuntu_focal.Dockerfile
@@ -4,8 +4,8 @@ FROM ghcr.io/itopia-inc/spaces-base-images/spaces-ubuntu-base:focal
 LABEL org.opencontainers.image.description="itopia Spaces image for Node.js + WebStorm on Ubuntu"
 LABEL org.opencontainers.image.source="https://github.com/itopia-inc/spaces-images"
 
-COPY languages/NodeJS/install_NodeJS_12_on_Ubuntu_focal.sh /usr/share/dev-scripts/
-RUN bash -ce '/usr/share/dev-scripts/install_NodeJS_12_on_Ubuntu_focal.sh'
+COPY languages/NodeJS/install_NodeJS_18_on_Ubuntu_focal.sh /usr/share/dev-scripts/
+RUN bash -ce '/usr/share/dev-scripts/install_NodeJS_18_on_Ubuntu_focal.sh'
 
 COPY IDEs/WebStorm/install_WebStorm.sh /usr/share/dev-scripts/
 RUN bash -ce '/usr/share/dev-scripts/install_WebStorm.sh'

--- a/languages/NodeJS/NodeJS_18_on_Ubuntu_focal.Dockerfile
+++ b/languages/NodeJS/NodeJS_18_on_Ubuntu_focal.Dockerfile
@@ -4,5 +4,5 @@ FROM ghcr.io/itopia-inc/spaces-base-images/spaces-ubuntu-base:focal
 LABEL org.opencontainers.image.description="itopia Spaces image with Node.js on Ubuntu"
 LABEL org.opencontainers.image.source="https://github.com/itopia-inc/spaces-images"
 
-COPY languages/NodeJS/install_NodeJS_12_on_Ubuntu_focal.sh /usr/share/dev-scripts/
-RUN bash -ce '/usr/share/dev-scripts/install_NodeJS_12_on_Ubuntu_focal.sh'
+COPY languages/NodeJS/install_NodeJS_18_on_Ubuntu_focal.sh /usr/share/dev-scripts/
+RUN bash -ce '/usr/share/dev-scripts/install_NodeJS_18_on_Ubuntu_focal.sh'

--- a/languages/NodeJS/install_NodeJS_18_on_Ubuntu_focal.sh
+++ b/languages/NodeJS/install_NodeJS_18_on_Ubuntu_focal.sh
@@ -2,6 +2,6 @@
 
 # See https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions
 # and https://github.com/nodesource/distributions#installation-instructions.
-curl -fsSL https://deb.nodesource.com/setup_12.x | sudo -E bash -
-VERSION=$(apt list -a nodejs 2>&1 | grep -e 'nodejs.*12' | cut -d' ' -f2)
+curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
+VERSION=$(apt list -a nodejs 2>&1 | grep -e 'nodejs.*18' | cut -d' ' -f2)
 sudo apt-get install -y nodejs=${VERSION?}


### PR DESCRIPTION
Node.js v18 is now "current", and Node.js v12 is no longer "maintained": https://nodejs.org/en/about/releases/